### PR TITLE
Continous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,26 @@
 language: cpp
-compiler: clang
+compiler:
+  - gcc
+
+before_install:
+  # g++4.8.1
+  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+  # clang 3.4
+  - if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
+
+  - sudo apt-get update -qq
+
+install:
+  # g++4.8.1
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
+
+  # clang 3.4
+  - if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
+  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
+
+  - sudo apt-get install -qq -y xorg-dev libglu1-mesa-dev uuid-dev
+
 before_script:
   - cmake .
-script: make
+script: make VERBOSE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: cpp
+compiler: clang
+before_script:
+  - cmake .
+script: make

--- a/lib/glfw/CMakeLists.txt
+++ b/lib/glfw/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(GLFW C)
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8)
 
 set(GLFW_VERSION_MAJOR "3")
 set(GLFW_VERSION_MINOR "1")


### PR DESCRIPTION
This adds a `.travis.yml` file that does an Ubuntu 12.04 build.

Since Travis has a sort of outdated build environment (I guess they're working on it) this uses GCC, and I also had to drop glfw's CMake minimum.

This should give you some confidence that things are still working on Linux when you're working on Mac. Next I'll try to get this building on Mac, and if Travis ever finally adds support, on Windows.

Here's a working build: <https://travis-ci.org/pnc/gfk/builds/55582553>

Once merged, you'll need to enable the Travis CI integration for the main repo.

Right now it just makes sure the build doesn't have errors—if you have a test suite, I can make it run that, too.